### PR TITLE
fix: add missing ecs:TagResource permission for ECS tasks

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -176,7 +176,7 @@ function getGluePermissions() {
 
 function getEcsPermissions() {
   return [{
-    action: 'ecs:RunTask,ecs:StopTask,ecs:DescribeTasks,iam:PassRole',
+    action: 'ecs:RunTask,ecs:StopTask,ecs:DescribeTasks,ecs:TagResource,iam:PassRole',
     resource: '*',
   }, {
     action: 'events:PutTargets,events:PutRule,events:DescribeRule',

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1651,7 +1651,7 @@ describe('#compileIamRole', () => {
       .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
       .Properties.Policies[0].PolicyDocument.Statement;
 
-    const ecsPermissions = statements.filter(s => _.isEqual(s.Action, ['ecs:RunTask', 'ecs:StopTask', 'ecs:DescribeTasks', 'iam:PassRole']));
+    const ecsPermissions = statements.filter(s => _.isEqual(s.Action, ['ecs:RunTask', 'ecs:StopTask', 'ecs:DescribeTasks', 'ecs:TagResource', 'iam:PassRole']));
     expect(ecsPermissions).to.have.lengthOf(1);
     expect(ecsPermissions[0].Resource).to.equal('*');
 
@@ -2694,7 +2694,7 @@ describe('#compileIamRole', () => {
     const expectation = (policy, lambdaArns, sns, sqsArn) => {
       const statements = policy.PolicyDocument.Statement;
 
-      const ecsPermissions = statements.filter(s => _.isEqual(s.Action, ['ecs:RunTask', 'ecs:StopTask', 'ecs:DescribeTasks', 'iam:PassRole']));
+      const ecsPermissions = statements.filter(s => _.isEqual(s.Action, ['ecs:RunTask', 'ecs:StopTask', 'ecs:DescribeTasks', 'ecs:TagResource', 'iam:PassRole']));
       expect(ecsPermissions).to.have.lengthOf(1);
       expect(ecsPermissions[0].Resource).to.equal('*');
 


### PR DESCRIPTION
## Summary
- Adds the missing `ecs:TagResource` permission to auto-generated IAM policies for ECS tasks
- Updates corresponding tests to verify the new permission is included

## Problem
When using serverless-step-functions to deploy ECS tasks with tags, the auto-generated IAM policies were missing the `ecs:TagResource` permission. This caused Step Functions executions to fail with an `AccessDeniedException` when attempting to tag ECS tasks.

## Solution
Added `ecs:TagResource` to the list of permissions in the `getEcsPermissions()` function in `lib/deploy/stepFunctions/compileIamRole.js`.

## Test plan
- [x] All existing tests pass
- [x] Updated tests to verify the new permission is included in the generated IAM policies

Fixes #656

🤖 Generated with [Claude Code](https://claude.ai/code)